### PR TITLE
multiple-fixes

### DIFF
--- a/src/BaselineOfSystemInteraction/BaselineOfSystemInteraction.class.st
+++ b/src/BaselineOfSystemInteraction/BaselineOfSystemInteraction.class.st
@@ -27,7 +27,7 @@ BaselineOfSystemInteraction >> baseline: spec [
 			spec
 				group: 'default' with: #('Core');
 				group: 'Core' with: #('SystemInteraction');
-				group: 'TinyLogger' with: #('SystemInteraction-TinyLogger') ]
+				group: 'TinyLoggerIntegration' with: #('SystemInteraction-TinyLogger') ]
 ]
 
 { #category : #dependencies }

--- a/src/SystemInteraction/AbstractFileReference.extension.st
+++ b/src/SystemInteraction/AbstractFileReference.extension.st
@@ -4,5 +4,5 @@ Extension { #name : #AbstractFileReference }
 AbstractFileReference >> escapedPathForSystemCommand [
 	"System commands need escaped path in case they contains some characters such as spaces or parenthesis. I am here to escape them if needed."
 
-	^ self pathString escapedPathForSystemCommand
+	^ self asAbsolute pathString escapedPathForSystemCommand
 ]

--- a/src/SystemInteraction/SICommand.class.st
+++ b/src/SystemInteraction/SICommand.class.st
@@ -314,7 +314,7 @@ SICommand >> waitForCommand: aString arguments: aCollection silently: aBoolean [
 		execute: [ aBoolean
 				ifTrue: [ self privateSilentWaitForCommand: aString arguments: aCollection ]
 				ifFalse: [ result := self privateWaitForCommand: aString arguments: aCollection ] ]
-		recordedAs: 'Execute command: ' , (self joinCommand: aString withArguments: aCollection).
+		loggedAs: 'Execute command: ' , (self joinCommand: aString withArguments: aCollection).
 
 	aBoolean ifFalse: [ self loggingStrategy trace: ('Result: ' , result asString ifEmpty: [ 'No result' ]) ].
 	^ result

--- a/src/SystemInteraction/SIWindowsCommand.class.st
+++ b/src/SystemInteraction/SIWindowsCommand.class.st
@@ -40,12 +40,11 @@ SIWindowsCommand class >> zipWindowExecutable [
 
 { #category : #'services - file operations' }
 SIWindowsCommand >> copyAll: inputDirectoryFileReference to: targetDirectoryFileReference [
-	"We add a \ character at the end of the target path, so that xcopy does not prompt the user (is it a file or a directory ?)
-	The /Y allows to force overwrite"
+	"see: https://docs.microsoft.com/fr-fr/windows-server/administration/windows-commands/robocopy"
 
 	^ self
-		waitForCommand: 'copy'
-		arguments: { " '/E' . '/Y'" . inputDirectoryFileReference escapedPathForSystemCommand . (targetDirectoryFileReference asAbsolute pathString , '\') escapedPathForSystemCommand}
+		waitForCommand: 'robocopy'
+		arguments: {'/e' . '/s' . inputDirectoryFileReference escapedPathForSystemCommand . targetDirectoryFileReference escapedPathForSystemCommand}
 ]
 
 { #category : #'services - file operations' }

--- a/src/SystemInteraction/SIWindowsCommand.class.st
+++ b/src/SystemInteraction/SIWindowsCommand.class.st
@@ -44,13 +44,15 @@ SIWindowsCommand >> copyAll: inputDirectoryFileReference to: targetDirectoryFile
 	The /Y allows to force overwrite"
 
 	^ self
-		waitForCommand: 'xcopy'
-		arguments: {'/E' . '/Y' . inputDirectoryFileReference asAbsolute escapedPathForSystemCommand . (targetDirectoryFileReference asAbsolute pathString , '\') escapedPathForSystemCommand}
+		waitForCommand: 'copy'
+		arguments: { " '/E' . '/Y'" . inputDirectoryFileReference escapedPathForSystemCommand . (targetDirectoryFileReference asAbsolute pathString , '\') escapedPathForSystemCommand}
 ]
 
 { #category : #'services - file operations' }
 SIWindowsCommand >> deleteAll: inputDirectoryFileReference [
-	^ self waitForCommand: 'rd' arguments: {'/s' . '/q' . inputDirectoryFileReference asAbsolute escapedPathForSystemCommand}
+	^ inputDirectoryFileReference isFile
+		ifTrue: [ self waitForCommand: 'del' arguments: {'/s' . '/q' . inputDirectoryFileReference escapedPathForSystemCommand} ]
+		ifFalse: [ self waitForCommand: 'rd' arguments: {'/s' . '/q' . inputDirectoryFileReference escapedPathForSystemCommand} ]
 ]
 
 { #category : #private }
@@ -77,7 +79,7 @@ SIWindowsCommand >> unzip: anArchive to: targetDirectory [
 	command := self systemInteractionResourcesFolder / 'unzip.exe'.
 	command exists ifFalse: [ command binaryWriteStreamDo: [ :s | s nextPutAll: self class unzipWindowExecutable ] ].
 	^ self
-		waitForCommand: command escapePathForSystemCommand
+		waitForCommand: command escapedPathForSystemCommand
 		arguments: {'-o' . anArchive escapedPathForSystemCommand . '-d' . targetDirectory escapedPathForSystemCommand}
 ]
 
@@ -90,5 +92,5 @@ SIWindowsCommand >> zip: aCollectionOfFilesOrPath to: aZipArchiveName [
 	arguments := OrderedCollection with: '-roq' with: aZipArchiveName.
 	arguments addAll: (aCollectionOfFilesOrPath collect: #escapedPathForSystemCommand).
 
-	self waitForCommand: command escapePathForSystemCommand arguments: arguments asArray silently: true
+	self waitForCommand: command escapedPathForSystemCommand arguments: arguments asArray silently: true
 ]


### PR DESCRIPTION
Multiple fixes

- Fix baseline (two times the  same group)
- Do not use tiny logger API in the core
- Fix windows commandes